### PR TITLE
Spring 2024 cleaning

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,16 +2,28 @@
   "name": "Python 3",
   "image": "mcr.microsoft.com/devcontainers/python:3.10",
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers-contrib/features/ansible:2": {},
-    "ghcr.io/devcontainers-contrib/features/flake8:2": {},
-    "ghcr.io/devcontainers-contrib/features/yamllint:2": {}
+      "ghcr.io/devcontainers/features/github-cli:1": {},
+      "ghcr.io/devcontainers-contrib/features/ansible:2": {},
+      "ghcr.io/devcontainers-contrib/features/yamllint:2": {},
+      "ghcr.io/hspaans/devcontainer-features/ansible-lint:1": {},
+      "ghcr.io/hspaans/devcontainer-features/pytest:1": {},
+      "ghcr.io/hspaans/devcontainer-features/pymarkdownlnt:1": {}
   },
   "customizations": {
-    "vscode": {
-      "extensions": [
-        "redhat.ansible"
-      ]
-    }
+      "vscode": {
+          "extensions": [
+              "EditorConfig.EditorConfig",
+              "ms-python.autopep8",
+              "ms-python.flake8",
+              "redhat.ansible",
+              "redhat.vscode-yaml"
+          ],
+          "[python]": {
+              "editor.defaultFormatter": "ms-python.autopep8",
+              "editor.formatOnSave": true
+          },
+          "ansible.python.interpreterPath": "/usr/local/bin/python",
+          "python.formatting.provider": "none"
+      }
   }
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,20 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: devcontainers
+    directory: /.devcontainer/
+    schedule:
+      interval: monthly
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: "2.16.0"
+  min_ansible_version: "2.17.0"
 
   platforms:
     - name: Alpine

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,18 +6,34 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 7.0.0
+  min_ansible_version: "2.16.0"
 
   platforms:
+    - name: Alpine
+      versions:
+        - "all"
     - name: Debian
       versions:
-        - buster
         - bullseye
         - bookworm
     - name: Ubuntu
       versions:
         - focal
         - jammy
+        - noble
+    - name: Fedora
+      versions:
+        - "39"
+        - "40"
+    - name: OracleLinux
+      versions:
+        - "9.2"
+    - name: Amazon Linux
+      versions:
+        - "2023"
+    - name: Rocky
+      versions:
+        - "9.2"
 
   galaxy_tags:
     - ssh

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -12,8 +12,17 @@ lint: |
   # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
   flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 platforms:
-  - name: debian-10
-    image: "ghcr.io/hspaans/molecule-containers:debian-10"
+  - name: amazonlinux-2023
+    image: "ghcr.io/hspaans/molecule-containers:amazonlinux-2023"
+    command: ""
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+
+  - name: alpine-3.20
+    image: "ghcr.io/hspaans/molecule-containers:alpine-3.20"
     command: ""
     cgroupns_mode: host
     volumes:
@@ -39,8 +48,8 @@ platforms:
     privileged: true
     pre_build_image: true
 
-  - name: fedora-38
-    image: "ghcr.io/hspaans/molecule-containers:fedora-38"
+  - name: oraclelinux-9
+    image: "ghcr.io/hspaans/molecule-containers:oraclelinux-9"
     command: ""
     cgroupns_mode: host
     volumes:
@@ -48,8 +57,8 @@ platforms:
     privileged: true
     pre_build_image: true
 
-  - name: fedora-39
-    image: "ghcr.io/hspaans/molecule-containers:fedora-39"
+  - name: rockylinux-9
+    image: "ghcr.io/hspaans/molecule-containers:rockylinux-9"
     command: ""
     cgroupns_mode: host
     volumes:
@@ -77,6 +86,24 @@ platforms:
 
   - name: ubuntu-24.04
     image: "ghcr.io/hspaans/molecule-containers:ubuntu-24.04"
+    command: ""
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+
+  - name: fedora-39
+    image: "ghcr.io/hspaans/molecule-containers:fedora-39"
+    command: ""
+    cgroupns_mode: host
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    privileged: true
+    pre_build_image: true
+
+  - name: fedora-40
+    image: "ghcr.io/hspaans/molecule-containers:fedora-40"
     command: ""
     cgroupns_mode: host
     volumes:


### PR DESCRIPTION
This commit updates the devcontainer.json file to include additional extensions for Visual Studio Code, such as EditorConfig, ms-python.autopep8, ms-python.flake8, redhat.ansible, and redhat.vscode-yaml. It also sets the default formatter for Python files to ms-python.autopep8 and enables formatting on save. Additionally, the ansible.python.interpreterPath is set to /usr/local/bin/python and the python.formatting.provider is set to none.

The molecule.yml file is also updated to use different platform images for testing. The amazonlinux-2023 and alpine-3.20 platforms are added, and the existing debian-10 platform is replaced with debian-10. The oraclelinux-9 and rockylinux-9 platforms are also added.